### PR TITLE
Don't complete on existing grouping variables

### DIFF
--- a/R/safety_summary.R
+++ b/R/safety_summary.R
@@ -133,7 +133,7 @@ safety_summary <- function(data, exposed, excess_deaths=0, freq_threshold=0, soc
       summarise(subjectsAffected=length(unique(subjid)),
                 occurrences=dplyr::n()
       ) %>%
-      tidyr::complete(group, tidyr::nesting(term, soc), fill=list("subjectsAffected"=0, "occurrences"=0)) %>%
+      tidyr::complete(group, fill=list("subjectsAffected"=0, "occurrences"=0)) %>%
       rename("groupTitle"="group") %>%
       left_join(soc_code, by=c("soc"=soc_index)) %>% ungroup() %>%
       select(groupTitle,subjectsAffected, occurrences,term,eutctId)
@@ -158,7 +158,7 @@ safety_summary <- function(data, exposed, excess_deaths=0, freq_threshold=0, soc
                 deaths=sum(fatal),
                 deathsCausallyRelatedToTreatment=sum(fatal*related)
       ) %>%
-      tidyr::complete(group, tidyr::nesting(term, soc),
+      tidyr::complete(group,
                       fill=list("subjectsAffected"=0,
                                 "occurrences"=0,
                                 "occurrencesCausallyRelatedToTreatment"=0,


### PR DESCRIPTION
We are planning on releasing tidyr 1.2.0 towards the end of this month.

We noticed in revdeps that this package was broken. An easy way to reproduce is to install the dev version of tidyr and run this example:

``` r
library(eudract)

safety_statistics <- safety_summary(
  safety,
  exposed=c("Experimental"=60,"Control"=67)
)
#> Error: Problem with `summarise()` input `..1`.
#> ℹ `..1 = complete(data = dplyr::cur_data(), ..., fill = fill, explicit = explicit)`.
#> x object 'term' not found
#> ℹ The error occurred in group 1: term = "Abdominal pain", soc = 10017947.
```

The problem comes down to the fact that you were trying to call `complete()` with a grouped data frame, and you were completing on the group columns. This is actually not well defined, as `complete()` already completes "within" each group, so you really shouldn't have access to the group variables.  The previous behavior was problematic in many cases (see https://github.com/tidyverse/tidyr/issues/396 and https://github.com/tidyverse/tidyr/issues/966), so we've made a fix to ensure that `complete()` works correctly with grouped data frames in all cases. This fix comes with the restriction that now you can't specify the group variables in the call to `complete()`.

It looks like you were attempting to do what `complete()` already does with grouped data frames, i.e. complete on the `group` column "within" each data frame group. So this PR just removes the `nesting()` call.

This should work on both the current and development version of tidyr, so you should be able to go ahead and do a patch release. We would greatly appreciate if you could do this so we can release tidyr! Thank you!